### PR TITLE
update to dvuploader v1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:21
-ARG VERSION=v1.1.0
+ARG VERSION=v1.2.1
 WORKDIR /opt/app
 ADD https://github.com/GlobalDataverseCommunityConsortium/dataverse-uploader/releases/download/$VERSION/DVUploader-$VERSION.jar DVUploader.jar
 ENTRYPOINT ["java", "-jar", "DVUploader.jar"]


### PR DESCRIPTION
the [1.2.1 release](https://github.com/GlobalDataverseCommunityConsortium/dataverse-uploader/releases/tag/v1.2.1) includes a fix to recursive uploads from a directory structure.