### PR TITLE
DEV-877: mount an existing Dataverse volume as /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.13-slim
 WORKDIR /opt/app
 
 # Install python-dvuploader dependencies
-COPY requirements.txt /tmp
-RUN pip install -r /tmp/requirements.txt
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 
 ENTRYPOINT [ "dvuploader" ]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ exec docker run \
      --init \
      --rm  \
      --volume /srv/da:/srv/da:ro \
+     --volume /srv/dataverse-prod/dvsantee/etl/dvuploader-tmp:/tmp \
      --volume /srv/dataverse-prod/dvsantee/etl/processing:/srv/dataverse:ro \
      ghcr.io/berkeleylibrary/dvuploader:latest "$@"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,5 @@ services:
     image: ghcr.io/berkeleylibrary/dvuploader:${USER:-default}-development
     volumes:
       - /srv/da:/opt/app/da:ro
+      - /srv/dataverse-prod/dvsantee/etl/dvuploader-tmp:/tmp
       - /srv/dataverse-prod/dvsantee/etl/processing:/opt/app/dataverse:ro

--- a/scripts/dvuploader.sh
+++ b/scripts/dvuploader.sh
@@ -3,5 +3,6 @@ exec docker run \
      --init \
      --rm  \
      --volume /srv/da:/srv/da:ro \
+     --volume /srv/dataverse-prod/dvsantee/etl/dvuploader-tmp:/tmp \
      --volume /srv/dataverse-prod/dvsantee/etl/processing:/srv/dataverse:ro \
      ghcr.io/berkeleylibrary/dvuploader:latest "$@"


### PR DESCRIPTION
this modifies the configurations to expect a new directory, `/srv/dataverse-prod/dvsantee/etl/dvuploader-tmp`, to exist, which will be mounted within the container as `/tmp`. this will allow us address issues where the container's root volume is running out of space.