### PR TITLE
upgrade to python-dvuploader 0.3.0 and allocate a pseudo-tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dataverse       -> /srv/dataverse-prod
 
 ## Permissions
 
-You don't necessarily want to give docker rights to users of this script, since docker implies root permissions. You can extend a limited ability to run the script with the following workaround:
+You don't necessarily want to give docker rights to users of this script, since docker implies root permissions. You can extend a limited ability to run the script with the following workaround (see [`scripts`](scripts)):
 
 ```sh
 # In system-wide profile
@@ -22,6 +22,7 @@ alias dvuploader="sudo /usr/local/sbin/dvuploader.sh"
 # In /usr/local/sbin/dvuploader.sh
 #!/bin/sh -e
 exec docker run \
+     -t \
      --init \
      --rm  \
      --volume /srv/da:/srv/da:ro \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# once dvuploader 0.3.0 is out, point this to a proper release spec
-dvuploader @ https://github.com/BerkeleyLibrary/python-dvuploader/archive/refs/heads/include-tab-ingest-rebased.zip
+dvuploader >= 0.3.0

--- a/scripts/dvuploader.sh
+++ b/scripts/dvuploader.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 exec docker run \
+     -t \
      --init \
      --rm  \
      --volume /srv/da:/srv/da:ro \


### PR DESCRIPTION
* allocate a pseudo-tty
  * python-dvuploader uses typer, which gives fancy progress bars, etc.; without a pseudotty, the output doesn't auto update or get the nice color formatting.
* upgrade to python-dvuploader 0.3.0
  * gets us off our prerelease fork